### PR TITLE
Add materials and update teaching module

### DIFF
--- a/Create SDRF.ipynb
+++ b/Create SDRF.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "888301cb-544d-45ed-9100-c7893fbb57a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e40954cb-ee9c-47d8-a5de-065a175c0797",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_table('sdrf (3).tsv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f5251dd-2e6e-4c3a-9189-b7f463bbe178",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['comment[instrument]'] = 'Q Exactive'\n",
+    "df['comment[technical replicate]'] = 1\n",
+    "df['characteristics[organism]'] = 'Homo Sapiens'\n",
+    "df['characteristics[organism part]'] = 'breast'\n",
+    "df['comment[fraction identifier]'] = df['comment[data file]'].str.extract(r'fr(\\d+).raw').astype(int)\n",
+    "df['comment[file uri]'] = 'https://storage.jpostdb.org/JPST000265/' + df['comment[data file]']\n",
+    "df['technology type'] = 'proteomic profiling by mass spectrometry'\n",
+    "df['characteristics[ancestry category]'] = 'not available'\n",
+    "df['characteristics[age]'] = 'not available'\n",
+    "df['characteristics[sex]'] = 'female'\n",
+    "df['characteristics[cell type]'] = 'malignant cell'\n",
+    "df['characteristics[biological replicate]'] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "578230a6-3ccf-41ff-9731-9eefe0d2b55f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tumor_id = pd.read_excel('41467_2019_9018_MOESM3_ESM.xlsx', sheet_name='Tumor annotations', usecols=['Tumor ID', 'TMT set nr', 'TMT tag', 'PAM50 subtype'], index_col=(1, 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7beb75d9-bb9b-45bc-8628-a08559b2c220",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tumor_id.index = pd.MultiIndex.from_tuples([(s, str(label)) for s, label in tumor_id.index], names=tumor_id.index.names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ead191c9-aef3-431a-816c-c15273f052df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tumor_types = {\n",
+    "    'Basal': 'basal-like breast carcinoma',\n",
+    "    'LumA': 'luminal A breast carcinoma',\n",
+    "    'LumB': 'luminal B breast carcinoma',\n",
+    "    'HER2': 'HER2 Positive Breast Carcinoma',\n",
+    "    'Normal': 'Normal Breast-Like Subtype of Breast Carcinoma'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "65f5a20e-4d12-48cc-9a32-cdcecad4f602",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Tumor ID</th>\n",
+       "      <th>PAM50 subtype</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TMT set nr</th>\n",
+       "      <th>TMT tag</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1</th>\n",
+       "      <th>126</th>\n",
+       "      <td>OSL.53E</td>\n",
+       "      <td>Basal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127N</th>\n",
+       "      <td>OSL.567</td>\n",
+       "      <td>LumA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127C</th>\n",
+       "      <td>OSL.3FF</td>\n",
+       "      <td>Basal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>128N</th>\n",
+       "      <td>OSL.55F</td>\n",
+       "      <td>Basal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>128C</th>\n",
+       "      <td>OSL.46A</td>\n",
+       "      <td>Basal</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   Tumor ID PAM50 subtype\n",
+       "TMT set nr TMT tag                       \n",
+       "1          126      OSL.53E         Basal\n",
+       "           127N     OSL.567          LumA\n",
+       "           127C     OSL.3FF         Basal\n",
+       "           128N     OSL.55F         Basal\n",
+       "           128C     OSL.46A         Basal"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tumor_id.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8ecf547f-1594-48f2-aa54-67cdc4257620",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pool_str = 'SN=' + ','.join(tumor_id['Tumor ID'].values)\n",
+    "\n",
+    "def get_info(row):\n",
+    "    pool = int(re.search(r'pool(\\d)', row['comment[data file]']).group(1))\n",
+    "    try:\n",
+    "        sample = tumor_id.loc[(pool, row['comment[label]'][3:]), 'Tumor ID']\n",
+    "        disease = tumor_types[tumor_id.loc[(pool, row['comment[label]'][3:]), 'PAM50 subtype']]\n",
+    "        pooled = 'not pooled'\n",
+    "    except KeyError:\n",
+    "        sample = 'pool'\n",
+    "        disease = 'breast cancer'\n",
+    "        pooled = pool_str\n",
+    "    assay = f\"pool {pool}, fraction {row['comment[fraction identifier]']}\"\n",
+    "    return sample, assay, pooled, disease"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f37d664a-a044-4b38-96de-d2e561819468",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[['source name', 'assay name', 'characteristics[pooled sample]', 'characteristics[disease]']] = df.apply(get_info, axis=1, result_type='expand')\n",
+    "df['factor value[disease]'] = df['characteristics[disease]']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ab2be8a8-237f-4ae1-bdc7-b70024f828bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def key(colname):\n",
+    "    if colname == 'source name':\n",
+    "        return 0\n",
+    "    if colname[:15] == 'characteristics':\n",
+    "        return 1\n",
+    "    if colname == 'assay name':\n",
+    "        return 2\n",
+    "    if colname == 'technology type':\n",
+    "        return 3\n",
+    "    if colname[:7] == 'comment':\n",
+    "        return 4\n",
+    "    if colname[:12] == 'factor value':\n",
+    "        return 5\n",
+    "    return 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c95778b3-4230-4890-bf9b-7b276a8667cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df[sorted(df.columns, key=key)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1dde5960-3afc-4f25-a71d-dddd58cedb8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.to_csv('PXD008841.sdrf.tsv', sep='\\t', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdrf.qmd
+++ b/sdrf.qmd
@@ -1,0 +1,103 @@
+---
+title: "Breast Cancer Proteomics Module: SDRF"
+summary: Teaching module provided for the proteomics module. 
+date: last-modified
+author: Lev Levitsky
+hide:
+  - navigation
+---
+
+
+::: {.question}
+Suppose you want to reproduce the figures from the article. What do you need for that, except the experimental data files?
+:::
+
+### SDRF metadata format
+
+Familiarize yourself with the **Sample and Data Relationship Format for Proteomics** - its [general description](https://github.com/bigbio/proteomics-sample-metadata)
+and take a look at the [specification](https://github.com/bigbio/proteomics-sample-metadata/blob/master/sdrf-proteomics/README.adoc). Then answer a few questions:
+
+::: {.question}
+What is the general layout of an SDRF file?
+:::
+
+::: {.question}
+What is the scope of information contained in an SDRF file?
+:::
+
+::: {.question}
+What columns would capture the most important sample characteristics for the dataset you are working with?
+:::
+
+::: {.question}
+How are the valid values defined for different columns?
+:::
+
+
+We will now create an annotation for a small subset of our data according to SDRF-Proteomics standard. Go to [lesSDRF](https://lessdrf.streamlit.app/),
+then start a new SDRF annotation with the human template. When asked for file names, input only the first RAW file name from the annotation table found in supporting information.
+After that, proceed to step 2, labeling.
+
+Carefully select the list of labels corresponding to the dataset, then click "Submit selection", and proceed to specify that every label is present in "ALL" files. Then click "Ready" and proceed to step 3.
+
+::: {.question}
+How many rows does the SDRF table have now? How many would it have if we annotated the entire dataset?
+:::
+
+Fill in the first three required columns one by one: source name, organism, and organism part.
+
+::: {.question}
+What would be a good sample identifier for the "source name" column?
+:::
+
+Fill in the next column, cell type. Consider that we are dealing with cancer samples. For the next columns, ancestry category and age, you can select "not available".
+Then, fill in the "sex" column.
+
+It is time to fill in the disease column.
+
+::: {.question}
+How many different values for disease can we possibly have in our annotation? What do they correspond to?
+:::
+
+::: {.question}
+How many different values will we actually use when annotating the selected subset of data?
+:::
+
+Proceed to fill the disease column, then fill in the rest of the columns, up to and including "instrument".
+
+::: {.question}
+How many different values should you use in the "assay name" column when annotating the subset? Why? How many different values should there be in the entire annotation?
+:::
+
+When you have only four columns left (cleavage agent details, modifications, precursor and fragment mass tolerance), skip to step 4 and fill the factor value column.
+
+::: {.question}
+What is the meaning of factor value, and what should it be in this case?
+:::
+
+After that, download the resulting file. Copy the cleavage agent, modifications and mass tolerance information from the partial annotation provided by FragPipe into your file,
+using Excel or similar software. Congratulations! You have a complete annotation according to the SDRF standard, but only for one out of all raw files in the data set.
+If you need a grade for this course, submit your SDRF file together with your answers.
+
+::: {.question}
+How would you go about making a full dataset annotation?
+:::
+
+## Personal Details
+
+**Name:**
+<textarea id="name" placeholder="Type your name here..." class="input-box"></textarea>
+
+**Email:**
+<textarea id="email" placeholder="Type your email here..." class="input-box"></textarea>
+
+**Course/Program:**
+<textarea id="course" placeholder="Type your course/program here..." class="input-box"></textarea>
+
+**Date:**
+<textarea id="date" placeholder="Type the date here..." class="input-box"></textarea>
+
+<button id="downloadBtn" class="download-button">Download Your Answers as PDF</button>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js"></script>
+

--- a/teachingmodule.qmd
+++ b/teachingmodule.qmd
@@ -64,7 +64,6 @@ By the end of this module, you will be equipped to manage TMT-labeled proteomics
 
 
 
-
 ## Preliminary work
 
 For this work, we will use the data that was used and analyzed in the paper *[Breast cancer quantitative proteome and proteogenomic landscape](https://www.nature.com/articles/s41467-019-09018-y)* by Johansson *et al.*, which compares subgroups of breast cancer tumors from the Oslo2 cohort.
@@ -108,6 +107,7 @@ Briefly describe TMT-labeled mass spectrometry proteomics data and explain the e
 #### TMT10-Tags and Tumor IDs
 
 Fill in the table below by entering the corresponding TMT10-tags and Tumor IDs. Once submitted, you'll get instant feedback on whether your input is correct.
+When you have filled the whole table correctly, download the annotation files, **you will need them later**.
 
 <form id="tmtForm">
   <table style="width: 100%; border-collapse: collapse;">
@@ -193,11 +193,11 @@ Fill in the table below by entering the corresponding TMT10-tags and Tumor IDs. 
     </tr>
     <tr>
       <td>TMT131</td>
-      <td><input type="text" id="set1_131" name="set1_131" class="input-box"></td>
-      <td><input type="text" id="set2_131" name="set2_131" class="input-box"></td>
-      <td><input type="text" id="set3_131" name="set3_131" class="input-box"></td>
-      <td><input type="text" id="set4_131" name="set4_131" class="input-box"></td>
-      <td><input type="text" id="set5_131" name="set5_131" class="input-box"></td>
+      <td><input type="text" id="set1_131N" name="set1_131" class="input-box"></td>
+      <td><input type="text" id="set2_131N" name="set2_131" class="input-box"></td>
+      <td><input type="text" id="set3_131N" name="set3_131" class="input-box"></td>
+      <td><input type="text" id="set4_131N" name="set4_131" class="input-box"></td>
+      <td><input type="text" id="set5_131N" name="set5_131" class="input-box"></td>
     </tr>
   </table>
   <button type="button" onclick="checkAnswers()" class="download-button">Submit</button>
@@ -218,7 +218,7 @@ Fill in the table below by entering the corresponding TMT10-tags and Tumor IDs. 
     set1_129C: 'OSL.4D6', set2_129C: 'OSL.449', set3_129C: 'OSL.441', set4_129C: 'OSL.53D', set5_129C: 'OSL.4BA',
     set1_130N: 'OSL.485', set2_130N: 'OSL.44E', set3_130N: 'OSL.430', set4_130N: 'OSL.540', set5_130N: 'OSL.579',
     set1_130C: 'OSL.41B', set2_130C: 'OSL.3EB', set3_130C: 'OSL.4FA', set4_130C: 'OSL.42E', set5_130C: 'OSL.57B',
-    set1_131: 'Pool', set2_131: 'Pool', set3_131: 'Pool', set4_131: 'Pool', set5_131: 'Pool'
+    set1_131N: 'Pool', set2_131N: 'Pool', set3_131N: 'Pool', set4_131N: 'Pool', set5_131N: 'Pool'
   };
 
   function checkAnswers() {
@@ -237,15 +237,14 @@ Fill in the table below by entering the corresponding TMT10-tags and Tumor IDs. 
 
   function downloadFiles() {
     const sets = ['set1', 'set2', 'set3', 'set4', 'set5'];
-    const tmtLabels = ['TMT126', 'TMT127N', 'TMT127C', 'TMT128N', 'TMT128C',
-                       'TMT129N', 'TMT129C', 'TMT130N', 'TMT130C', 'TMT131'];
+    const tmtLabels = ['126', '127N', '127C', '128N', '128C', '129N', '129C', '130N', '130C', '131N'];
 
     sets.forEach((set) => {
       let content = '';
       
       // Iterate over each TMT label
       tmtLabels.forEach(label => {
-        const input = document.getElementById(`${set}_${label.slice(-3)}`) || document.getElementById(`${set}_${label.slice(-3, -1)}N`) || document.getElementById(`${set}_${label.slice(-3, -1)}C`);
+        const input = document.getElementById(`${set}_${label}`);
         const userAnswer = input ? input.value.trim() : '';
         content += `${label}\t${userAnswer}\n`;
       });
@@ -324,7 +323,7 @@ What are the benefits of using FragPipe?
 :::
 
 
-
+Now that we know what we want to do and why, it is time to start the **Proteomics Sandbox** application, or job.
 Simple analyses in **FragPipe** may only require 8 GB of RAM, while large-scale or complex analyses may require 24 GB of memory or more ([FragPipe Documentation](https://fragpipe.nesvilab.org/docs/tutorial_fragpipe.html#:~:text=FragPipe%20runs%20on%20Windows%20and,24%20GB%20memory%20or%20more.)), which is why we will allocate 24 GB for this exercise.
 
 In UCloud, the settings should look like this:
@@ -346,49 +345,44 @@ Time can pass quickly when working, so we recommend initially allocating 2 hours
 
 Initially, we will need to download the paper's data. For this exercise, we will only use one sample file from each Plex Set/Pool.
 
-We will use the terminal in the virtual environment for downloading the data. First, we need to update and download the necessary packages. You can do that by typing the following code:
+We will use the terminal in the virtual environment for downloading the data.
 
-```bash
-sudo apt-get update
-sudo apt-get install lftp
-```
-
-::: {.question}
-What does the code above do? Please explain its functionality and purpose.
-:::
-
-
-Now, we can access the FTP server where the data is located. You will need the server address from the correct FTP-server, which can be found on the site for the accession code XXX in ProteomeXchange, previously visited. At the bottom of the page, you will find the FTP-server address where the data is stored.
+Now, we can access the FTP server where the data is located. You will need the server address from the correct FTP-server, which can be found on the site for the accession code PXD008841 in ProteomeXchange, previously visited.
+At the bottom of the page, you will find the FTP-server address where the data is stored.
 
 ::: {.question}
 Please locate the address.
 :::
 
-
-The address is used for accessing the data used in the study. To do so, we can use the package lftp that we just installed to access the server using the following code:
-
-```bash
-lftp [insert the address of the FTP server here]
-lftp ftp://ftp.......
-```
+Click on the "Dataset FTP location" link.
 
 ::: {.question}
 We now have access to the data stored on the FTP server. Please provide a brief description of the contents of the folder on the FTP server.
 :::
 
 
-To download one sample file from each of the Plex Sets, you can use the following code in the terminal:
+To download one sample file from each of the Plex Sets, we will need these URLs only:
 
-##### CODE HERE
 
-::: {.question}
-Please explain what the code is doing by describing the functions used.
+```
+{{< include urls.txt >}}
+```
+
+(you can also download this list [here](https://github.com/hds-sandbox/proteomics-sandbox/blob/webpage/urls.txt)).
+
+::: {.callout-note}
+We recommend to open this material inside **Proteomics Sandbox** to be able to copy & paste or download the file directly into the environment.
 :::
 
+After you save the list of URLs into a file named `urls.txt`. you can use the following code in the terminal:
+
+```
+wget -i urls.txt
+```
 
 If you added your own private folder to the UCloud session, you could now move the data into that folder for better management of the data you're working with.
 
-Next, we can launch FragPipe, which is located on the desktop. In this tutorial, we are using FragPipe version XX.YY in the June 2024 version of the Proteomics Sandbox Application.
+Next, we can launch FragPipe, which is located on the desktop. In this tutorial, we are using FragPipe version **22.0** in the October 2024 version of the **Proteomics Sandbox** Application.
 
 Now that we have launched FragPipe, we need to configure the settings prior to running the analysis. Therefore, we have provided some guiding questions to help you set up the settings in FragPipe:
 
@@ -402,9 +396,12 @@ Which workflow should you select? HINT: How many TMT tags are listed in the tabl
 
 Click ‘Load workflow’ after you have found and selected the correct workflow to be used.
 
-Next, add your files by clicking on “Add files” and locate them in the designated folder for your raw files that you previously created.
+Next, add your files by clicking on “Add files” and locate them in the designated folder for your raw files that you previously created. Assign each file to a separate *experiment* by clicking "Consecutive".
 
-Now you should relocate to the “Database” tab. Here you can either download or browse for an already preexisting database file. In this case, we will simply download the latest database file.
+Go to the "Quant (Isobaric)" tab. Here, you need to provide annotations for TMT channels. Use the five pool annotations that you downloaded from this page.
+You will need to upload them to Ucloud and specify the corresponding annotation file for each experiement in order.
+
+Now you should relocate to the “Database” tab. Here you can either download or browse for an already preexisting database file. In this case, we will simply download the latest database file by clicking the "Download" button in FragPipe.
 
 ::: {.question}
 What is the purpose of the database file used in FragPipe, and why is it important?

--- a/urls.txt
+++ b/urls.txt
@@ -1,0 +1,5 @@
+https://storage.jpostdb.org/JPST000265/HJOS2U_20140410_TMTpool1_300ugIPG37-49_7of15ul_fr01.raw
+https://storage.jpostdb.org/JPST000265/HJOS2U_20140410_TMTpool2_300ugIPG37-49_7of15ul_fr01.raw
+https://storage.jpostdb.org/JPST000265/HJOSLO2U_QEHF_20150318_TMT_pool3_300ugIPG37-49_7of15ul_fr01.raw
+https://storage.jpostdb.org/JPST000265/HJOSLO2U_QEHF_20150322_TMT_pool4_300ugIPG37-49_7of15ul_fr01.raw
+https://storage.jpostdb.org/JPST000265/HJOSLO2U_QEHF_20150329_TMT_pool5_300ugIPG37-49_7of15ul_fr01.raw


### PR DESCRIPTION
- Add `sdrf.qmd` and `Create SDRF.ipynb`. They are not yet accessible from the index page.

In the teaching module:

- Fix the script for table download (previously not all channel annotations were extracted).
- "Hidden" fix in table code for FragPipe compatibility: it expects "131N" instead of "131" even though we use TMT10 and does not recognize "TMT" in channel names (?!).
- Add `wget` instructions and URL list for download, remove mentions of `lftp`.
- Expand instructions about FragPipe config (especially Quant tab).